### PR TITLE
Opam point merlin to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ opam switch 4.02.3
 eval `opam config env`
 opam update
 opam pin add -y merlin 'https://github.com/the-lambda-church/merlin.git'
-opam pin add -y merlin_extend 'https://github.com/let-def/merlin-extend.git#reason-0.0.1'
+opam pin add -y merlin_extend 'https://github.com/let-def/merlin-extend.git'
 opam pin add -y reason 'https://github.com/facebook/reason.git#0.0.6'
 
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ opam init
 opam switch 4.02.3
 eval `opam config env`
 opam update
-opam pin add -y merlin 'https://github.com/the-lambda-church/merlin.git#reason-0.0.1'
+opam pin add -y merlin 'https://github.com/the-lambda-church/merlin.git'
 opam pin add -y merlin_extend 'https://github.com/let-def/merlin-extend.git#reason-0.0.1'
 opam pin add -y reason 'https://github.com/facebook/reason.git#0.0.6'
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian
 RUN sudo -u opam sh -c "opam depext -u merlin utop"
 RUN opam remote add main https://opam.ocaml.org && \
-    opam pin add -y merlin https://github.com/the-lambda-church/merlin.git#reason-0.0.1 && \
-    opam pin add -y merlin_extend https://github.com/let-def/merlin-extend.git#reason-0.0.1 && \
+    opam pin add -y merlin https://github.com/the-lambda-church/merlin.git && \
+    opam pin add -y merlin_extend https://github.com/let-def/merlin-extend.git && \
     opam pin add -y reason https://github.com/facebook/reason.git#0.0.6


### PR DESCRIPTION
The reason-branches are gone from merlin and merlin-extend, we should no longer point to those.